### PR TITLE
fix(next): import Link only once in backbutton.js

### DIFF
--- a/client/src/components/shared/button/BackButton.js
+++ b/client/src/components/shared/button/BackButton.js
@@ -3,7 +3,6 @@ import Link from 'next/link';
 
 import { Button, makeStyles } from '@material-ui/core';
 import { ChevronLeft } from 'react-feather';
-import Link from 'next/link';
 import theme from '../../../config/themes/light';
 
 function BackButton({ path, goTo }) {


### PR DESCRIPTION
### Your checklist for this pull request

🚨Please review the [guidelines for contributing](../CONTRIBUTING.md) to this repository.

- [x] Make sure you are requesting to **pull a topic/feature/bugfix branch** (right side). Don't request your default branch!
- [x] Make sure you make a pull request against the **default branch** (left side). Also you should start _your branch_ off _default branch_.
- [x] Check the commit's or even all commits' message styles matches our requested structure.
- [x] Check your code additions will fail neither code linting checks nor unit test.
- [x] I have added necessary documentation (if appropriate)

### Description

This Pull request is made to resolve the issue mentioned in issue145
https://github.com/Monday-Morning/project-tahiti/issues/145

Link is imported twice in the backbutton.js file. 
(path: /client/src/component/shared/button/backbutton.js ) [As per the structure of next branch on 15th December 2021.]

Due to which the About page is not opening. 
This PR fixes the issue by importing the Link component only once. 

### Post merge checklist

- [x] Follow steps from the [guidelines for contributing](../CONTRIBUTING.md) to this repository.
- [ ] If you are a new contributor, ping in the thread and one of the maintainers will add you to all-contributors list.
