### PR TITLE
Bug Fix: Preserved Dark Mode state using Local Storage

### DIFF
--- a/client/src/context/ThemeContext.jsx
+++ b/client/src/context/ThemeContext.jsx
@@ -20,6 +20,15 @@ const ThemeContextProvider = ({ children }) => {
   useEffect(() => {
     const currentHour = new Date().getHours();
     setDarkTheme(currentHour >= 20 || currentHour <= 8 ? true : false);
+    localStorage.setItem(
+      'darkTheme',
+      currentHour >= 20 || currentHour <= 8 ? 'true' : 'false',
+    );
+    if (localStorage.getItem('darkTheme') === 'true') {
+      setDarkTheme(true);
+    } else if (localStorage.getItem('darkTheme') === 'false') {
+      setDarkTheme(false);
+    }
   }, [setDarkTheme]);
 
   return (


### PR DESCRIPTION
In this commit, I resolved a bug where the Dark Mode state was erroneously resetting to the default setting. By applying a solution that leverages Local Storage, I've successfully rectified this issue. Users can now enjoy a seamless and uninterrupted Dark Mode experience, with their preferences consistently preserved.
